### PR TITLE
increase HardwareSerial Rx DMA buffer size from 128 up to 512 bytes

### DIFF
--- a/hardware/nrf54l15clean/nrf54l15clean/cores/nrf54l15/HardwareSerial.h
+++ b/hardware/nrf54l15clean/nrf54l15clean/cores/nrf54l15/HardwareSerial.h
@@ -62,7 +62,7 @@ private:
     static constexpr uint16_t kRxRingSize = 1024U;
     // Keep enough hardware-backed RX slack to survive short BLE timing-critical
     // sections without dropping bridge UART bytes.
-    static constexpr uint8_t kRxDmaChunkSize = 128U;
+    static constexpr uint16_t kRxDmaChunkSize = 512U;
     static constexpr uint8_t kTxDmaChunkSize = 64U;
 
     NRF_UARTE_Type* _uart;


### PR DESCRIPTION

When I use `BleNusBridge.ino` sketch with GNSS module connected  to `Serial1`@ 9600 BPS  - I can see that some of NMEA data gets corrupt:

```
$GPRMC,121348.00,V,,,,,,,170426,,,N*76
$GPVTG,,,,,,,,,N*30
$GPGGA,121348.00,,,,,0,00,99.99,,,,,,*6B
$GPGSA,A,1,,,,,,,,,,,,,99.99,99GPGSV,1,1,04,04,,,22,05,,,24,09,,,22,31,,,23*70
$GPGLL,,,,,121348.00,V,N*47
$GPRMC,121349.00,V,,,,,,,170426,,,N*77
$GPVTG,,,,,,,,,N*30
$GPGGA,121349.00,,,,,0,00,99.99,,,,,,*6A
$GPGSA,A,1,,,,,,,,,,,,,99.99,99PGSV,2,1,06,04,,,22,05,,,20,08,,,22,09,,,22*7E
$GPGSV,2,2,06,14,,,24,31,,,22*7E
$GPGLL,,,,,121349.00,V,N*46
$GPRMC,121350.00,V,,,,,,,170426,,,N*7F
$GPVTG,,,,,,,,,N*30
```

Increase of `kRxDmaChunkSize` value up to 512 helps to fix this.

Value 512 is legal because MAXCNT <= 32767 as specified in the nRF54L15 datasheet.

<img width="1545" height="442" alt="image" src="https://github.com/user-attachments/assets/6ca6de04-9dae-444d-afa2-8c2c1329e4c7" />


